### PR TITLE
Resolving editorial review from RG

### DIFF
--- a/draft-ietf-tsvwg-dscp-considerations-04.xml
+++ b/draft-ietf-tsvwg-dscp-considerations-04.xml
@@ -883,10 +883,10 @@ This was previously specified as the Inter-Service Provider IP Backbone Guidelin
 	In this case, bleaching, or
         remarking to "CS0" would result in elevating the lower effort traffic
         (LE) to the default class (BE/CS0).  This is an example of priority
-        inversion (in which packets marked with a LE DSCP  that were
+        inversion (in which packets marked with an LE DSCP that were
 	intended to be forwarded with lower
-	precedence thn default are instead forwarded with
-        a precedence higher than used for BE packets, see section 6 
+	precedence than default are instead forwarded with
+        a precedence higher than used for BE packets, see section 6
 	of <xref target="RFC8622"></xref>).</t>
        </section>
 

--- a/draft-ietf-tsvwg-dscp-considerations-04.xml
+++ b/draft-ietf-tsvwg-dscp-considerations-04.xml
@@ -894,10 +894,10 @@ This was previously specified as the Inter-Service Provider IP Backbone Guidelin
         experienced. For example, it can be desirable to avoid choosing a DSCP
         that could be remarked to LE, <xref target="RFC8622">Lower
         Effort</xref>, which could otherwise potentially result in a priority
-        inversion in the treatment (in which packets marked with a LE DSCP
-	that were  intended to be forwarded with lower
-        precedence thn default are instead forwarded with
-        a precedence higher than used for BE packets, see 
+        inversion in the treatment. For example,  packets marked with a LE DSCP
+	(which were intended to be forwarded with lower
+        assurance than default) are instead forwarded with
+        a higher assurance, see 
 	section 6 of <xref target="RFC8622">)</t>
       </section>
 

--- a/draft-ietf-tsvwg-dscp-considerations-04.xml
+++ b/draft-ietf-tsvwg-dscp-considerations-04.xml
@@ -882,12 +882,7 @@ This was previously specified as the Inter-Service Provider IP Backbone Guidelin
         case when defining the LE PHB <xref target="RFC8622"></xref>. 
 	In this case, bleaching, or
         remarking to "CS0" would result in elevating the lower effort traffic
-        (LE) to the default class (BE/CS0).  This is an example of priority
-        inversion (in which packets marked with an LE DSCP that were
-	intended to be forwarded with lower
-	precedence than default are instead forwarded with
-        a precedence higher than used for BE packets, see section 6
-	of <xref target="RFC8622"></xref>).</t>
+        (LE) to the default class (BE/CS0).</t>
        </section>
 
       <section title="Where the proposed DSCP &gt; 0x07 (7)">
@@ -899,7 +894,11 @@ This was previously specified as the Inter-Service Provider IP Backbone Guidelin
         experienced. For example, it can be desirable to avoid choosing a DSCP
         that could be remarked to LE, <xref target="RFC8622">Lower
         Effort</xref>, which could otherwise potentially result in a priority
-        inversion in the treatment.</t>
+        inversion in the treatment (in which packets marked with a LE DSCP
+	that were  intended to be forwarded with lower
+        precedence thn default are instead forwarded with
+        a precedence higher than used for BE packets, see 
+	section 6 of <xref target="RFC8622">)</t>
       </section>
 
       <section title="Where the proposed DSCP &lt; 0x07 (7)">

--- a/draft-ietf-tsvwg-dscp-considerations-04.xml
+++ b/draft-ietf-tsvwg-dscp-considerations-04.xml
@@ -516,7 +516,7 @@ A DSCP can sometimes be referred to by name, such as "CS1", and
           <t></t>
 
           <t>If ToS Precedence Bleaching occurs, packets with a DSCP 'x' would
-          be remarked to 'x' &amp; 0x07and then would be treated according to the corresponding PHB.</t>
+          be remarked to 'x' &amp; 0x07 and then would be treated according to the corresponding PHB.</t>
 
           <t>A variation of this observed remarking behaviour clears the top three bits of a
           DSCP, unless these have values 0b110 or 0b111 (corresponding to the

--- a/draft-ietf-tsvwg-dscp-considerations-04.xml
+++ b/draft-ietf-tsvwg-dscp-considerations-04.xml
@@ -892,13 +892,12 @@ This was previously specified as the Inter-Service Provider IP Backbone Guidelin
         DSCP is greater than 0x07 should consider the semantics
         associated with the resulting DSCP when ToS Precedence Bleaching is
         experienced. For example, it can be desirable to avoid choosing a DSCP
-        that could be remarked to LE, <xref target="RFC8622">Lower
-        Effort</xref>, which could otherwise potentially result in a priority
-        inversion in the treatment. For example,  packets marked with a LE DSCP
-	(which were intended to be forwarded with lower
-        assurance than default) are instead forwarded with
-        a higher assurance, see 
-	section 6 of <xref target="RFC8622">)</t>
+        of format 0bXXXXX1. This could be remarked to LE (0x01) <xref target="RFC8622">Lower
+		Effort</xref>, which would result in a priority
+        inversion in the treatment, where instead of being forwarded with
+        a higher assurance, the packets are forwarded with a lower
+        assurance than default  (see 
+	section 6 of <xref target="RFC8622">).</t>
       </section>
 
       <section title="Where the proposed DSCP &lt; 0x07 (7)">

--- a/draft-ietf-tsvwg-dscp-considerations-04.xml
+++ b/draft-ietf-tsvwg-dscp-considerations-04.xml
@@ -325,7 +325,7 @@ A DSCP can sometimes be referred to by name, such as "CS1", and
         same forwarding treatment. DSCPs can be mapped to treatment
         aggregates that might result in remarking (e.g., <xref
         target="RFC5160">RFC5160</xref> suggests Meta-QoS-Classes to help
-        enable deployment of standardized end-to-end QoS classes)</t>
+        enable deployment of standardized end-to-end QoS classes).</t>
 
       </section>
 
@@ -568,11 +568,7 @@ A DSCP can sometimes be referred to by name, such as "CS1", and
 	Both <xref target="RFC2474">RFC2474</xref> and <xref
         target="RFC8100">RFC8100</xref> recommend that DiffServ boundary nodes use
         remarking, if necessary, to avoid theft/denial of service or ensure that
-        appropriate DSCPs are used within a DiffServ domain.  Some networks therefore
-        may not follow the earlier recommendation in <xref
-        target="RFC2474">RFC2474</xref> to carry unknown or unexpected DSCPs without
-        modification, and instead remark packets with these codepoints to the default
-        class, CS0 (0x00). 
+        appropriate DSCPs are used within a DiffServ domain.  
          </t>
 
         <t>
@@ -872,8 +868,8 @@ This was previously specified as the Inter-Service Provider IP Backbone Guidelin
     </section>
 
     <section title="Considerations for DSCP Selection">
-      <t>This section provides advice for the assignment of a new DSCP value.
-        It is intended to aid the IETF and IESG in considering a request for a new DSCP.
+      <t>This section provides advice to aid the IETF and IESG in considering a request for
+      assigning a new DSCP.
       The section identifies known issues that might influence the finally assigned
       DSCP, and provides a summary of considerations for assignment of a new
       DSCP.</t>
@@ -883,11 +879,16 @@ This was previously specified as the Inter-Service Provider IP Backbone Guidelin
         can limit the ability to provide the expected treatment end-to-end.
         This is particularly important for cases where the codepoint is
         intended to result in lower than best effort treatment, as was the
-        case when defining the LE PHB <xref target="RFC8622"></xref>. In this
-        case, bleaching, or remarking to "CS0" would result in elevating the
-        lower effort traffic (LE) to the default class (BE/CS0). This is an example of
-        priority inversion.</t>
-      </section>
+        case when defining the LE PHB <xref target="RFC8622"></xref>. 
+	In this case, bleaching, or
+        remarking to "CS0" would result in elevating the lower effort traffic
+        (LE) to the default class (BE/CS0).  This is an example of priority
+        inversion (in which packets marked with a LE DSCP  that were
+	intended to be forwarded with lower
+	precedence thn default are instead forwarded with
+        a precedence higher than used for BE packets, see section 6 
+	of <xref target="RFC8622"></xref>).</t>
+       </section>
 
       <section title="Where the proposed DSCP &gt; 0x07 (7)">
         <t>Although the IETF specifications require systems to use DSCP
@@ -969,8 +970,7 @@ This was previously specified as the Inter-Service Provider IP Backbone Guidelin
 
             <t>Service classes <xref target="RFC4594"></xref> that can utilise existing PHBs should use
             assigned DSCPs to mark their traffic: Could the request be met by
-            using an existing IETF DSCP? The proposed new treatment be
-            used to map traffic to a new or existing PHB.</t>
+            using an existing IETF DSCP?</t>
 		
    	   <t>Is this a request to assign a new DSCP? 
 		   Specification of a new recommended DSCP requires Standards Action.


### PR DESCRIPTION
Editorial changes from TSVWG review. 
Two issues remain: - one related to unexpected DSCP and one related to text describing intent of DS wrt to ToS.