### PR TITLE
Update draft-ietf-tsvwg-dscp-considerations-04.xml

### DIFF
--- a/draft-ietf-tsvwg-dscp-considerations-04.xml
+++ b/draft-ietf-tsvwg-dscp-considerations-04.xml
@@ -421,6 +421,12 @@ A DSCP can sometimes be referred to by name, such as "CS1", and
           <t hangText="Remark:">remarks all traffic to one or more particular
           (non-zero) DSCP values.</t>
         </list></t>
+	    
+	<t>NOTE: There can be multiple mechanisms that can result in a
+	DSCP being remarked (see below). It
+	is not generally possible for an external observer to
+	determine which mechanism results in a specific remarking 
+	solely from the change in an observed DSCP value.</t>
 
       <section anchor="Bleaching" title="Bleaching the DSCP Field">
         <t>A specific form of remarking occurs when the DiffServ field is


### PR DESCRIPTION
Suggested PR to say that yopu can just "know" what caused a remarking, because for a single DSCP, the remarking could be due to various reasoins. .... Of course one could infer from a pattern of remarking or other info (but we don't need to explain that?)