### PR TITLE
PR to Address Review by Erik Kline

### DIFF
--- a/draft-ietf-tsvwg-dscp-considerations-12.xml
+++ b/draft-ietf-tsvwg-dscp-considerations-12.xml
@@ -1139,9 +1139,11 @@ of misconfiguration.
     </section>
 
     <section anchor="IANA" title="IANA Considerations">
-      <t>This memo provides information to assist in considering new
-      assignments to the IANA DSCP registry
-      (https://www.iana.org/assignments/dscp-registry/dscp-registry.xhtml).</t>
+      <t>IANA is requested to append “See [RFC-to-be] for considerations in assigning a new DSCP value.”
+   as a separate paragraph to the Note for the 
+	      Differentiated Services Field Codepoints (DSCP)
+   registries at the top of the registry page at 
+	      https://www.iana.org/assignments/dscp-registry/dscp-registry.xhtml .</t>
 
       <t>This memo includes no request to IANA, or update to the IANA
       procedures.</t>

--- a/draft-ietf-tsvwg-dscp-considerations-12.xml
+++ b/draft-ietf-tsvwg-dscp-considerations-12.xml
@@ -51,7 +51,7 @@
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
 
-<rfc category="info" docName="draft-ietf-tsvwg-dscp-considerations-12"
+<rfc category="info" docName="draft-ietf-tsvwg-dscp-considerations-13"
 
      ipr="trust200902" submissionType="IETF">
   <!-- category values: std, bcp, info, exp, and historic
@@ -134,7 +134,7 @@
       </address>
     </author>
 
-    <date day="13" month="February" year="2023" />
+    <date day="28" month="February" year="2023" />
 
     <area>TSVArea</area>
 
@@ -150,7 +150,7 @@
     <abstract>
       <t>This document discusses considerations for assigning a new
       recommended DiffServ Code Point (DSCP) for a new standard Per Hop Behavior (PHB). It considers the common
-      observed remarking behaviors  that the DiffServ field might be subjected to along
+      observed re-marking behaviors  that the DiffServ field might be subjected to along
       an Internet path. It also notes some implications of using a specific
       DSCP.</t>
     </abstract>
@@ -180,7 +180,8 @@ use a common IANA registry <xref target="DSCP-registry"></xref>.</t>
    PDB defines which PHB (or set of PHBs) and hence for a specific
    operator, which DSCP (or set of DSCPs) will be associated with
    specific BAs as the packets pass through a DiffServ domain, and
-   whether the packets are remarked as they are forwarded.</t>
+   whether the packets are re-marked as they are forwarded
+   (i.e., changing the DSCP of a packet <xref target="RFC2475"></xref>).</t>
 
 
       <t><figure>
@@ -201,7 +202,7 @@ Traffic        Class
         </figure></t>
 
       <t>This document discusses considerations for assigning a new DSCP for a standard PHB. It
-      considers some commonly observed DSCP remarking behaviors that might be
+      considers some commonly observed DSCP re-marking behaviors that might be
       experienced along an Internet path. It also describes some packet
       forwarding treatments that a packet with a specific DSCP can expect to
       receive when forwarded across a link or subnetwork.</t>
@@ -345,7 +346,7 @@ all capitals, as shown here.</t>
         as PHBs. Although DSCPs are intended to identify specific treatment
         requirements, multiple DSCPs might also be mapped (aggregated) to the
         same forwarding treatment. DSCPs can be mapped to treatment
-        aggregates that might result in remarking (e.g., <xref
+        aggregates that might result in re-marking (e.g., <xref
         target="RFC5160">RFC5160</xref> suggests Meta-QoS-Classes to help
         enable deployment of standard end-to-end QoS classes)</t>
 
@@ -360,7 +361,7 @@ all capitals, as shown here.</t>
         value from  a set of Class Selector (CS) DSCPs.
 	This traffic is
         often a special case within a provider network, and ingress traffic
-        with these DSCP markings can be remarked.</t>
+        with these DSCP markings can be re-marked.</t>
 
         <t>DSCP CS2 is recommended for the OAM (Operations, Administration,
         and Maintenance) service class (see <xref target="RFC4594"></xref>,
@@ -371,7 +372,7 @@ all capitals, as shown here.</t>
         network operation administration, control and management. Section 3.2
         of <xref target="RFC4594">RFC4594</xref> recommends that "CS6 marked
         packet flows from untrusted sources (for example, end-user devices)
-        SHOULD be dropped or remarked at ingress to the DiffServ network".</t>
+        SHOULD be dropped or re-marked at ingress to the DiffServ network".</t>
 
         <t>DSCP CS7 is reserved for future use by network control traffic.
         "CS7 marked packets SHOULD NOT be sent across peering points" <xref
@@ -385,23 +386,23 @@ all capitals, as shown here.</t>
 	actively used by network operators for control traffic. A study of 
         traffic at a large Internet Exchange showed around 40% of ICMP traffic 
 	carried this mark <xref target="IETF113-IEPG"></xref>. Similarly, another 
-	study found many routers remark all traffic except those packets with a DSCP
+	study found many routers re-mark all traffic except those packets with a DSCP
 	that sets the higher order bits to 0b11 (see Section 4 of this document).</t>
 
       </section>
     </section>
 
-    <section anchor="observed-remarking" title="Remarking the DSCP">
+    <section anchor="observed-re-marking" title="Re-marking the DSCP">
       <t>It is a feature of the DiffServ architecture that the DiffServ field
-      of packets can be remarked at the Diffserv domain boundaries (see Section 2.3.4.2 of
-      <xref target="RFC2475"></xref>). A DSCP can be remarked at the
-      ingress of a domain. This remarking
+      of packets can be re-marked at the Diffserv domain boundaries (see Section 2.3.4.2 of
+      <xref target="RFC2475"></xref>). A DSCP can be re-marked at the
+      ingress of a domain. This re-marking
       can change the DSCP value used on the remainder of an IP path, or the
       network  can restore the
       initial DSCP marking at the egress of the domain. The DiffServ
-      field can also be remarked based on common semantics and agreements
+      field can also be re-marked based on common semantics and agreements
       between providers at an exchange point. Furthermore, <xref target="RFC2474"></xref> states
-      that remarking must occur when there is a possibility of theft or denial-of-service attack.</t>
+      that re-marking must occur when there is a possibility of theft or denial-of-service attack.</t>
 
 	    <t>
 The treatment of packets that are marked with an unknown or an
@@ -413,16 +414,16 @@ recommends forwarding the packet using a
 default (best effort) treatment, but without changing the DSCP.
 This seeks to support incremental DiffServ deployment in existing networks
 as well as preserve DSCP markings by routers that have not been
-configured to support DiffServ. (See also <xref target="remark"></xref>).
+configured to support DiffServ. (See also <xref target="re-mark"></xref>).
 
-     <xref target="RFC3260"></xref> clarifies that this remarking specified by RFC2474
+     <xref target="RFC3260"></xref> clarifies that this re-marking specified by RFC2474
    is intended for interior nodes within a DiffServ domain. For DiffServ ingress nodes the
    traffic conditioning required by RFC 2475 applies first.
 </t>
 
       <t>Reports measuring existing deployments have defined a set of categories for DSCP
-      remarking <xref target="Cus17"></xref> <xref target="Bar18"></xref>
-      into the following seven observed remarking behaviors:</t>
+      re-marking <xref target="Cus17"></xref> <xref target="Bar18"></xref>
+      into the following seven observed re-marking behaviors:</t>
 
       <t><list style="hanging">
           <t hangText="Bleach-DSCP:">bleaches all traffic (sets the DSCP to
@@ -436,7 +437,7 @@ configured to support DiffServ. (See also <xref target="remark"></xref>).
           DSCP field to 0b000 (reset the 3 bits of the former ToS Precedence
           field), unless the first two bits of the DSCP field are 0b11;</t>
 
-          <t hangText="Remark-ToS:">set the first three bits of the DSCP field
+          <t hangText="Re-mark-ToS:">set the first three bits of the DSCP field
           to any value different than 0b000 (replace the 3 bits of the former
           ToS Precedence field);</t>
 
@@ -447,7 +448,7 @@ configured to support DiffServ. (See also <xref target="remark"></xref>).
           field to 0b000, unless the first two bits of the DSCP field are
           0b11;</t>
 
-          <t hangText="Remark-DSCP:">remarks all traffic to one or more particular
+          <t hangText="Re-mark-DSCP:">re-marks all traffic to one or more particular
           (non-zero) DSCP values.</t>
         </list></t>
 	<t>These behaviours are explained in the following subsections and
@@ -456,17 +457,17 @@ configured to support DiffServ. (See also <xref target="remark"></xref>).
         <t>
         The network nodes forming a particular path might or might not have supported DiffServ.
         It is not generally possible for an external observer to
-        determine which mechanism results in a specific remarking 
+        determine which mechanism results in a specific re-marking 
         solely from the change in an observed DSCP value.</t>
 
         <t>NOTE: More than one mechanism could result in the
-        same DSCP remarking (see below). These behaviors were measured on both IPv4 and 
+        same DSCP re-marking (see below). These behaviors were measured on both IPv4 and 
 	IPv6 Internet paths between 2017 and 2021<xref target="Cus17"></xref>.
-	IPv6 routers were found to perform all the types of remarking described 
+	IPv6 routers were found to perform all the types of re-marking described 
 	above to a lesser extent than IPv4 ones.</t>
 
       <section anchor="Bleaching" title="Bleaching the DSCP Field">
-        <t>A specific form of remarking occurs when the DiffServ field is
+        <t>A specific form of re-marking occurs when the DiffServ field is
         re-assigned to the default treatment, CS0 (0x00). This results in
         traffic being forwarded using the BE PHB. For example, AF31 (0x1a)
         would be bleached to CS0.</t>
@@ -492,15 +493,15 @@ configured to support DiffServ. (See also <xref target="remark"></xref>).
 
         <section title="Impact of ToS Precedence Bleaching ">
 	
-          <t>Bleaching of the ToS Precedence field (<xref target="observed-remarking">Bleach-ToS-Precedence</xref>) 
+          <t>Bleaching of the ToS Precedence field (<xref target="observed-re-marking">Bleach-ToS-Precedence</xref>) 
 	  resets the first three bits of the DSCP field to zero (the former
           ToS Precedence field), leaving the last three bits unchanged (see Section
           4.2.1 of <xref target="RFC2474"></xref>). A DiffServ node can be 
-	  configured in a way that results in this remarking. This remarking 
+	  configured in a way that results in this re-marking. This re-marking 
           can also occur when packets are processed by a router that is not configured 
 	   with DiffServ (e.g., configured to operate on the former ToS precedence field 
            <xref target="RFC0791"></xref>). At the time of writing, this is a common 
-           manipulation of the DiffServ field. The following Figure depicts this remarking.</t>
+           manipulation of the DiffServ field. The following Figure depicts this re-marking.</t>
 
           <figure>
             <preamble></preamble>
@@ -509,7 +510,7 @@ configured to support DiffServ. (See also <xref target="remark"></xref>).
 |0 0 0|x x x|
 +-+-+-+-+-+-+
 ]]></artwork>
-            <postamble>Figure showing bleaching of the ToS Precedence (<xref target="observed-remarking">Bleach-ToS-Precedence</xref>), 
+            <postamble>Figure showing bleaching of the ToS Precedence (<xref target="observed-re-marking">Bleach-ToS-Precedence</xref>), 
 		    based on Section 3 of <xref target="RFC1349"></xref>. The bit positions marked "x" are not changed.</postamble>
           </figure>
 
@@ -540,13 +541,13 @@ configured to support DiffServ. (See also <xref target="remark"></xref>).
 ]]></artwork>
 
             <postamble>Table of DSCP values. As a result of ToS Precedence Bleaching, each of the DSCPs in a 
-	    column are remarked to the smallest DSCP in that column. 
+	    column are re-marked to the smallest DSCP in that column. 
 	 Therefore, the DSCPs in the bottom row have higher survivability across an end-to-end Internet path.
             </postamble>
           </figure>
 
 
-<t>Data on the observed remarking at the time of writing was presented in <xref target="IETF113-IEPG"></xref>.</t>
+<t>Data on the observed re-marking at the time of writing was presented in <xref target="IETF113-IEPG"></xref>.</t>
 
           <figure>
             <preamble></preamble>
@@ -562,22 +563,24 @@ configured to support DiffServ. (See also <xref target="remark"></xref>).
 +===============+============+====+======+====+=========+====+
 ]]></artwork>
 
-            <postamble>Table showing 0b000xxx DSCPs. This highlights any current assignments and whether they are affected by any known remarking behaviors. 
+            <postamble>Table showing 0b000xxx DSCPs. This highlights any current assignments and whether 
+		    they are affected by any known re-marking behaviors. 
 	* DSCP 4 has been historically used by the SSH application<xref target="Kol10">.</xref>.
             </postamble>
           </figure>
 	      
           <t></t>
-	  <t>DSCPs of the form 0b000xxx can be impacted by known remarking behaviours of other assigned DSCPs. 
-	For example, ToS Precedence Bleaching of popular DSCPs AF11, AF21, AF31, AF41 would result in traffic being remarked with DSCP 2 in the Internet core.
+	  <t>DSCPs of the form 0b000xxx can be impacted by known re-marking behaviours of other assigned DSCPs. 
+	For example, ToS Precedence Bleaching of popular DSCPs AF11, AF21, AF31, AF41 would result 
+		  in traffic being re-marked with DSCP 2 in the Internet core.
 	The Lower-Effort Per-Hop Behavior PHB (LE) uses a DSCP of 4. This value has been historically used by the SSH application, 
 	following semantics that precede DiffServ <xref target="Kol10"></xref>.</t>  
 
-          <t><xref target="observed-remarking"> Bleach-ToS-Precedence </xref> of packets with a DSCP 'x' result in the DSCP being
-          remarked to 'x' &amp; 0x07 and then forwarded using the PHB specified for the resulting DSCP in that Diffserv domain. 
-	  In subsequent networks the packet will receive treatment as specified by the domain's operator corresponding to the remarked codepoint.</t>
+          <t><xref target="observed-re-marking"> Bleach-ToS-Precedence </xref> of packets with a DSCP 'x' result in the DSCP being
+          re-marked to 'x' &amp; 0x07 and then forwarded using the PHB specified for the resulting DSCP in that Diffserv domain. 
+	  In subsequent networks the packet will receive treatment as specified by the domain's operator corresponding to the re-marked codepoint.</t>
 		  
-          <t>A variation of this observed remarking behavior clears the top three bits of a
+          <t>A variation of this observed re-marking behavior clears the top three bits of a
           DSCP, unless these have values 0b110 or 0b111 (corresponding to the
           CS6 and CS7 DSCPs). As a result, a DSCP value greater than 48
           decimal (0x30) is less likely to be impacted by ToS Precedence
@@ -585,15 +588,15 @@ configured to support DiffServ. (See also <xref target="remark"></xref>).
 	
         </section>
 
-        <section title="Impact of ToS Precedence Remarking">
+        <section title="Impact of ToS Precedence Re-marking">
 	
           <t><xref target="RFC2474"></xref> states "Implementors should note that 
 	  the DSCP field is six bits wide. DS-compliant nodes MUST select PHBs
 	  by matching against the entire 6-bit
 DSCP field, e.g., by treating the value of the field as a table index
 which is used to select a particular packet handling mechanism which
-has been implemented in that device". This replaced remarking according 
-to ToS precedence (<xref target="observed-remarking">Remark-ToS</xref>) <xref target="RFC1349"></xref>. These practices based on ToS
+has been implemented in that device". This replaced re-marking according 
+to ToS precedence (<xref target="observed-re-marking">Re-mark-ToS</xref>) <xref target="RFC1349"></xref>. These practices based on ToS
 semantics have not yet been eliminated from deployed networks.</t>
 
           <figure>
@@ -606,28 +609,28 @@ semantics have not yet been eliminated from deployed networks.</t>
 
 ]]></artwork>
 
-            <postamble>Figure showing the ToS Precedence Remarking (<xref target="observed-remarking">Remark-ToS</xref>)
+            <postamble>Figure showing the ToS Precedence Re-marking (<xref target="observed-re-marking">Re-mark-ToS</xref>)
             observed behavior, based on Section 3 of <xref
             target="RFC1349"></xref>. The bit positions marked "x" remain unchanged.</postamble>
 
           </figure>
 
-          <t>A less common remarking, ToS Precedence Remarking sets the first
+          <t>A less common re-marking, ToS Precedence Rem-arking sets the first
           three bits of the DSCP to a non-zero value corresponding to a
-          CS PHB. This remarking occurs when routers are not configured to perform DiffServ remarking.
+          CS PHB. This re-marking occurs when routers are not configured to perform DiffServ re-marking.
           </t>
 
-<t>If ToS Precedence Remarking occurs, packets are forwarded using the PHB specified for the resulting DSCP in that domain. 
-For example, the AF31 DSCP (0x1a) could be remarked to either AF11 or AF21. 
-If such a remarked packet further traverses other Diffserv domains, 
-it would receive treatment as specified by each domain's operator corresponding to the remarked codepoint.</t>
+<t>If ToS Precedence Re-marking occurs, packets are forwarded using the PHB specified for the resulting DSCP in that domain. 
+For example, the AF31 DSCP (0x1a) could be re-marked to either AF11 or AF21. 
+If such a re-marked packet further traverses other Diffserv domains, 
+it would receive treatment as specified by each domain's operator corresponding to the re-marked codepoint.</t>
 	        </section>
       </section>
 
-      <section anchor="remark" title="Remarking to a Particular DSCP">
+      <section anchor="re-mark" title="Re-marking to a Particular DSCP">
 
-        <t>A network device might remark the DiffServ field of an IP packet
-        based on a local policy with a specific (set of) DSCPs (<xref target="observed-remarking"> Remark-DSCP </xref>). 
+        <t>A network device might re-mark the DiffServ field of an IP packet
+        based on a local policy with a specific (set of) DSCPs (<xref target="observed-re-marking"> Re-mark-DSCP </xref>). 
         </t>
 
         <t>
@@ -635,22 +638,22 @@ it would receive treatment as specified by each domain's operator corresponding 
 	"Packets received with an unrecognized codepoint SHOULD be forwarded as if
 	they were marked for the Default behavior, and their codepoints
 	should not be changed."  Some networks might not follow this recommendation
-	and instead remark packets with these codepoints to the default class, CS0 (0x00). 
-        This remarking
+	and instead re-mark packets with these codepoints to the default class, CS0 (0x00). 
+        This re-marking
         is sometimes performed using a Multi-Field (MF) classifier <xref
         target="RFC2475"></xref> <xref target="RFC3290"></xref> <xref
         target="RFC4594"></xref>. 
          </t>
 
         <t>	
-        If remarking occurs, 
+        If re-marking occurs, 
 	packets are forwarded using the PHB specified for the resulting DSCP in that domain. 
-	As an example, remarking traffic AF31, AF32 and AF33 all to a single DSCP, e.g. AF11, stops 
+	As an example, re-marking traffic AF31, AF32 and AF33 all to a single DSCP, e.g. AF11, stops 
         any drop probability differentiation, which may have been expressed 
-        by these three DSCPs. If such a remarked packet further traverses 
+        by these three DSCPs. If such a re-marked packet further traverses 
         other domains, it would receive treatment as specified by the domain's operator 
-	corresponding to the remarked codepoint. Bleaching
-        (<xref target="observed-remarking">Bleach-DSCP</xref>) is a specific example of this observed remarking behavior that remarks to CS0
+	corresponding to the re-marked codepoint. Bleaching
+        (<xref target="observed-re-marking">Bleach-DSCP</xref>) is a specific example of this observed re-marking behavior that re-marks to CS0
         (0x00) - see <xref target="Bleaching"></xref>.</t>
 
       </section>
@@ -660,7 +663,7 @@ it would receive treatment as specified by each domain's operator corresponding 
       <t>Transmission systems and subnetworks can, and do, utilise the
       DiffServ field in an IP packet to set a QoS-related field or function at
      the lower layer.  A lower layer could also implement a traffic conditioning
-     function that could remark the DSCP used at the IP layer.  This
+     function that could re-mark the DSCP used at the IP layer.  This
       function is constrained by designs that
       utilise fewer than 6 bits to express the service class, and therefore
       infer a mapping to a smaller L2 QoS field, for example, 
@@ -696,7 +699,7 @@ it would receive treatment as specified by each domain's operator corresponding 
         Internet control traffic can be marked as CS6, and network control is
         marked as CS7.</t>
 
-	<t>Other remarking behaviors have also been implemented in Ethernet equipment. 
+	<t>Other re-marking behaviors have also been implemented in Ethernet equipment. 
 	Historically, a previous standard <xref target="IEEE-802-1D"></xref> 
 	used both PCP1 (Background) and
         PCP2 (Spare) to indicate lower priority than PCP0, and
@@ -719,7 +722,7 @@ it would receive treatment as specified by each domain's operator corresponding 
 	(which could be seen as a simple method to map IP layer DiffServ to layers offering only 3-bit QoS codepoints). Then, 
         in turn, this is mapped to the four WiFi Multimedia (WMM) Access
         Categories. The Wi-Fi Alliance has also specified a more flexible mapping 
-	that follows RFC8325 and provides functions at an AP to remark packets as 
+	that follows RFC8325 and provides functions at an AP to re-mark packets as 
         well as a QoS Map that maps each DSCP to an AC <xref target="WIFI-ALLIANCE"></xref>.</t>
 
        <figure>
@@ -739,8 +742,8 @@ it would receive treatment as specified by each domain's operator corresponding 
         <t></t>
 	       
         <t><xref target="RFC8325">RFC8325</xref> notes inconsistencies that
-        can result from such remarking, and recommends a different mapping to perform this
-        remarking, dependent on the direction in which a packet is forwarded.
+        can result from such re-marking, and recommends a different mapping to perform this
+        re-marking, dependent on the direction in which a packet is forwarded.
 	It provides recommendations for mapping a DSCP to an IEEE 802.11 UP 
 	for interconnection between wired and wireless networks. 
 	The recommendation in Section 5.1.2 maps network control traffic, CS6 and CS7, 
@@ -750,9 +753,9 @@ it would receive treatment as specified by each domain's operator corresponding 
 
         <t>For other UPs, RFC8325 recommends a mapping in the upstream direction that derives the 
 	DSCP from the value of the UP multiplied by 8. 
-	This mapping can result in a specific DSCP remarking behavior.</t>
-        <t>In the upstream direction (wireless-to-wired interconnections, 
-	this mapping can result in a specific DSCP remarking behavior.
+	This mapping can result in a specific DSCP re-marking behavior.</t>
+        <t>In the upstream direction (wireless-to-wired interconnections), 
+	this mapping can result in a specific DSCP re-marking behavior.
         Some Access Points (APs) currently use a
         default UP-to-DSCP mapping <xref target="RFC8325"></xref>,
         wherein "DSCP values are derived from the layer 2 UP values by
@@ -765,7 +768,7 @@ it would receive treatment as specified by each domain's operator corresponding 
         case where there is no other classification and marking policy
         enforcement point, then this derived DSCP value will be used on the
         remainder of the Internet path." This can result in
-        remarking by <xref target="observed-remarking">Bleach-low</xref>.</t>
+        re-marking by <xref target="observed-re-marking">Bleach-low</xref>.</t>
 
         <figure>
           <preamble></preamble>
@@ -777,7 +780,7 @@ it would receive treatment as specified by each domain's operator corresponding 
 
 ]]></artwork>
 
-          <postamble>Figure showing the observed remarking behavior resulting from deriving from UP-to-DSCP mapping in some
+          <postamble>Figure showing the observed re-marking behavior resulting from deriving from UP-to-DSCP mapping in some
          802.11 networks.</postamble>
         </figure>
 	
@@ -862,13 +865,13 @@ it would receive treatment as specified by each domain's operator corresponding 
          limits the number of acceptable external DSCPs (and possibilities for their
          transparent transport or restoration at network boundaries).  In this design,
          packets marked with DSCPs not part of the RFC8100 codepoint scheme are treated
-         as unexpected and will possibly be remarked (a <xref target="observed-remarking">Remark-DSCP</xref> behavior) or dealt
+         as unexpected and will possibly be re-marked (a <xref target="observed-re-marking">Re-mark-DSCP</xref> behavior) or dealt
          with via an additional agreement(s) among the operators of the interconnected
          networks.  RFC8100 can be extended to support up to 32 DSCPs by future
          standards. RFC8100 is operated by at least one Tier 1 backbone provider.  Use
-         of the MPLS Short Pipe Model favours remarking unexpected DSCP values to zero
+         of the MPLS Short Pipe Model favours re-marking unexpected DSCP values to zero
          in the absence of an additional agreement(s), as explained in <xref
-         target="RFC8100"></xref>. This can result in bleaching (<xref target="observed-remarking">Bleach-DSCP</xref>).
+         target="RFC8100"></xref>. This can result in bleaching (<xref target="observed-re-marking">Bleach-DSCP</xref>).
          </t>
 
           <figure>
@@ -928,7 +931,7 @@ This was previously specified as the Inter-Service Provider IP Backbone Guidelin
 		scheme at outer headers and inner IPX DSCPs may be transported transparently. 
 		The guidelines also describe a case where the DSCP marking from a Service 
 		Provider cannot be trusted (depending on the agreement between the Service Provider 
-		and its IPX Provider), in which situation the IPX Provider can remark 
+		and its IPX Provider), in which situation the IPX Provider can re-mark 
 		the DSCP value to a static default value.
         </t>
 
@@ -971,14 +974,14 @@ This was previously specified as the Inter-Service Provider IP Backbone Guidelin
         headers <xref target="MEF23.1"></xref>.</t>
       </section>
 
-      <section title="Remarking as a Side-effect of Another Policy">
-        <t>This includes any other remarking that does not happen as a result of traffic conditioning, such as
-         policies and L2 procedures that result in remarking traffic as
+      <section title="Re-marking as a Side-effect of Another Policy">
+        <t>This includes any other re-marking that does not happen as a result of traffic conditioning, such as
+         policies and L2 procedures that result in re-marking traffic as
         a side-effect of other functions (e.g., in response to Distributed Denial of Service, DDoS).</t>
       </section>
 
       <section title="Summary">
-        <t>This section has discussed the various ways in which DSCP remarking behaviors can arise from interactions with lower layers.</t>
+        <t>This section has discussed the various ways in which DSCP re-marking behaviors can arise from interactions with lower layers.</t>
 	     <t> A provider service path may consist of sections where multiple and 
    changing layers use their own code points to determine
 		     differentiated forwarding (e.g., IP - MPLS - IP - Ethernet - WiFi).</t>
@@ -992,10 +995,10 @@ This was previously specified as the Inter-Service Provider IP Backbone Guidelin
       DSCP, and provides a summary of considerations for assignment of a new
       DSCP.</t>
 
-      <section title="Effect of Bleaching and Remarking to a single DSCP">
-        <t>Section 4 describes remarking of the DSCP.
+      <section title="Effect of Bleaching and Re-marking to a single DSCP">
+        <t>Section 4 describes re-marking of the DSCP.
 	New DSCP assignments should consider the impact of bleaching
-  	(<xref target="observed-remarking">Bleach-DSCP</xref>) or remarking (<xref target="observed-remarking">Remark-DSCP</xref>) to a single DSCP, which can limit
+  	(<xref target="observed-re-marking">Bleach-DSCP</xref>) or rem-arking (<xref target="observed-re-marking">Re-mark-DSCP</xref>) to a single DSCP, which can limit
    	the ability to provide the expected treatment end-to-end.  This is
    	particularly important for cases where the codepoint is intended to
   	result in lower than best effort treatment, as was the case when
@@ -1005,8 +1008,8 @@ This was previously specified as the Inter-Service Provider IP Backbone Guidelin
   	end-to-end to allow for differentiated treatment by 
    	domains supporting LE. Rewriting the LE DSCP to the default class (CS0)
    	results in an undesired promotion of the priority for LE traffic in such a domain.
-   	Bleaching the lower three bits of the DSCP (both <xref target="observed-remarking">Bleach-low</xref>
-   	and <xref target="observed-remarking">Bleach-some-low</xref>), as well as remarking to a particular 
+   	Bleaching the lower three bits of the DSCP (both <xref target="observed-re-marking">Bleach-low</xref>
+   	and <xref target="observed-re-marking">Bleach-some-low</xref>), as well as re-marking to a particular 
   	 DSCP can result in similar changes of priority relative to traffic that is marked with other DSCPs.
 	 </t>
       </section>
@@ -1016,10 +1019,10 @@ This was previously specified as the Inter-Service Provider IP Backbone Guidelin
         marking semantics in place of methods based on the former ToS field,
         the current recommendation is that any new assignment where the
         DSCP is greater than 0x07 should consider the semantics
-        associated with the resulting DSCP when the ToS Precedence is bleached (<xref target="observed-remarking">Bleach-ToS-Precedence</xref> and <xref target="observed-remarking"> Bleach-some-ToS </xref>)
-	or ToS Precedence Remarking (<xref target="observed-remarking">Remark-ToS</xref>) is
+        associated with the resulting DSCP when the ToS Precedence is bleached (<xref target="observed-re-marking">Bleach-ToS-Precedence</xref> and <xref target="observed-re-marking"> Bleach-some-ToS </xref>)
+	or ToS Precedence Re-marking (<xref target="observed-re-marking">Re-mark-ToS</xref>) is
         experienced. For example, it can be desirable to avoid choosing a DSCP
-        that could be remarked to LE, <xref target="RFC8622">Lower
+        that could be re-marked to LE, <xref target="RFC8622">Lower
         Effort</xref>, which could otherwise potentially result in a priority
         inversion in the treatment.</t>
 	 <section title="Where the proposed DSCP&amp;0x07=0x01">
@@ -1028,52 +1031,52 @@ This was previously specified as the Inter-Service Provider IP Backbone Guidelin
           Pool 3.</t>
 
           <t>When making assignments where the DSCP has a format: 0bxxx001,
-          the case of <xref target="observed-remarking">Bleach-ToS-Precedence</xref> of a
+          the case of <xref target="observed-re-marking">Bleach-ToS-Precedence</xref> of a
           DSCP to a value of 0x01 needs to be considered. ToS Precedence
           Bleaching will result in demoting the traffic to the lower effort
           traffic class. Care should be taken to consider the implications
-	  of remarking
+	  of re-marking
           when choosing to  assign a DSCP with this format.</t>
         </section>
       </section>
 
       <section title="Where the proposed DSCP &lt;= 0x07 (7)">
-        <t>ToS Precedence Bleaching or ToS Precedence Remarking can unintentionally result in extra traffic
+        <t>ToS Precedence Bleaching or ToS Precedence Re-marking can unintentionally result in extra traffic
         aggregated to the same DSCP. For example, after experiencing ToS Precedence
         Bleaching, all traffic marked AF11, AF21, AF31 and AF41 would be
         aggregated with traffic marked with DSCP 2 (0x02), increasing the
         volume of traffic which receives the treatment associated with DSCP 2.
         New DSCP assignments should consider unexpected
-        consequences arising from this observed remarking behavior.</t>
+        consequences arising from this observed re-marking behavior.</t>
       </section>
 
       <section anchor= "networks" title="Impact on deployed infrastructure">
         <t>Behavior of deployed PHBs and conditioning treatments also needs
         to be considered when assigning a new DSCP. Network operators have choices
-        when it comes to configuring DiffServ support within their domains, and the observed remarking behaviors 
+        when it comes to configuring DiffServ support within their domains, and the observed re-marking behaviors 
 	described in the previous section can result from different configurations 
 	and approaches:</t>
         <t><list style="hanging">
-            <t hangText="Networks not remarking DiffServ:"> A network that either does not implement PHBs, or 
+            <t hangText="Networks not re-marking DiffServ:"> A network that either does not implement PHBs, or 
 		    implements one or more PHBs whilst restoring the DSCP field at network egress with the value 
 		    at network ingress. Operators in this category pass all DSCPs transparently.</t>
             <t hangText="Networks that condition the DSCP:"> A network that implements more than one PHB and enforces 
 	Service Level Agreements (SLAs) with its peers. Operators in this category use conditioning to ensure that
         only traffic that matches a policy is permitted to use a specific DSCP (see <xref target="RFC8100"></xref>). 
 	Operators need to classify the received traffic, assign it to a corresponding PHB, and could
-	remark the DSCP to a value that is appropriate for the domain's deployed DiffServ infrastructure.</t>		
-            <t hangText="Networks that remark in some other way, which includes:"> 
+	re-mark the DSCP to a value that is appropriate for the domain's deployed DiffServ infrastructure.</t>		
+            <t hangText="Networks that re-mark in some other way, which includes:"> 
             </t>
                 <t><list style='numbers'>
                 <t>Networks containing misconfigured devices that do not comply with the relevant RFCs.</t>
                 <t>Networks containing devices that implement an obsolete specification or contain software bugs.</t>
-                <t>Networks containing devices that remark the DSCP as a result of lower layer interactions.</t>
+                <t>Networks containing devices that re-mark the DSCP as a result of lower layer interactions.</t>
 		</list></t>
        </list></t>
       <t>
-	The DSCP re-marking corresponding to the <xref target="observed-remarking">Bleach-ToS-Precedence</xref>
+	The DSCP re-marking corresponding to the <xref target="observed-re-marking">Bleach-ToS-Precedence</xref>
 	observed behavior described in Section 4 can arise for various reasons, one of which is old equipment which precedes DiffServ.
-The same remarking can also arise in some cases when traffic conditioning is
+The same re-marking can also arise in some cases when traffic conditioning is
 provided by DiffServ routers at operator boundaries or as a result
 of misconfiguration.
 	 </t>
@@ -1104,7 +1107,8 @@ of misconfiguration.
         RFC2474 states: "Each standardized PHB MUST have an associated
         RECOMMENDED codepoint". If approved, new IETF assignments are normally
         made by IANA in Pool 1, but the IETF can request assignments to be
-        made from Pool 3 <xref target="RFC8436"></xref>. Does the ID contain an appropriate request to IANA?</t>
+        made from Pool 3 <xref target="RFC8436"></xref>. 
+	Does the Internet Draft contain an appropriate request to IANA?</t>
 
             <t>The value selected for a new DSCP can impact the ability of an operator to apply
 		    logical functions (e.g., a bitwise mask) to related codepoints when configuring DiffServ.
@@ -1119,9 +1123,9 @@ of misconfiguration.
             below IP. What are the implications of the treatments and mapping described in <xref target="lowerlayers"></xref> on the proposed DSCP? </t>
 		   
             <t> DSCPs are assigned to PHBs and can be used to enable nodes along an end-to-end path to classify the packet for a suitable PHB.
-	    <xref target="observed-remarking"></xref> describes some observed remarking behavior, 
-	    and <xref target="networks"></xref> identifies root causes for why this remarking is observed. 
-		    What is the expected effect of currently-deployed remarking on the service, end-to-end or otherwise?</t>
+	    <xref target="observed-re-marking"></xref> describes some observed re-marking behavior, 
+	    and <xref target="networks"></xref> identifies root causes for why this re-marking is observed. 
+		    What is the expected effect of currently-deployed re-marking on the service, end-to-end or otherwise?</t>
  
           </list></t>
       </section>
@@ -1421,7 +1425,7 @@ of misconfiguration.
            <t>Working Group -05
            <list style="hanging">
           <t>Clarify meaning of RFC2474 with respect to IP precedence (comments from Ruediger Geib).</t>
-          <t>Add note on understanding the process of remarking (comments from Ruediger Geib).</t>
+          <t>Add note on understanding the process of re-marking (comments from Ruediger Geib).</t>
           <t>Improve readability.</t>
           </list>
        	</t>
@@ -1429,10 +1433,10 @@ of misconfiguration.
            <t>Working Group -06
            <list style="hanging">
           <t>Quote RFC2474 with respect to IP precedence (comments from Ruediger Geib).</t>
-          <t>Ensure it is clear that different remarking processes may result in the same observed remarking.</t>
+          <t>Ensure it is clear that different re-marking processes may result in the same observed re-marking.</t>
           <t>Clarify Treatment Aggregates are part of methods such as MPLS (comments from David Black).</t>
-          <t>Clarify implications on the rest of the path by remarking in one domain. </t>
-          <t>Include all observed remarking behaviors in Section 6.</t>
+          <t>Clarify implications on the rest of the path by re-marking in one domain. </t>
+          <t>Include all observed re-marking behaviors in Section 6.</t>
           <t>Remove mentions of DSCP 5 being provisionally assigned to NQB.</t>
           <t>Clarify scope of network control traffic in Section 3.2.</t>
           <t>Improve readibility.</t>
@@ -1472,6 +1476,11 @@ of misconfiguration.
 <t>Working Group -12
            <list style="hanging">
           <t>Finalize response to AD review, address comment from Brian Carpenter.</t>
+          </list>
+        </t>
+<t>Working Group -13
+           <list style="hanging">
+          <t>Review by Erik Kline</t>
           </list>
         </t>
 

--- a/draft-ietf-tsvwg-dscp-considerations-12.xml
+++ b/draft-ietf-tsvwg-dscp-considerations-12.xml
@@ -615,7 +615,7 @@ semantics have not yet been eliminated from deployed networks.</t>
 
           </figure>
 
-          <t>A less common re-marking, ToS Precedence Rem-arking sets the first
+          <t>A less common re-marking, ToS Precedence Re-marking sets the first
           three bits of the DSCP to a non-zero value corresponding to a
           CS PHB. This re-marking occurs when routers are not configured to perform DiffServ re-marking.
           </t>
@@ -998,7 +998,7 @@ This was previously specified as the Inter-Service Provider IP Backbone Guidelin
       <section title="Effect of Bleaching and Re-marking to a single DSCP">
         <t>Section 4 describes re-marking of the DSCP.
 	New DSCP assignments should consider the impact of bleaching
-  	(<xref target="observed-re-marking">Bleach-DSCP</xref>) or rem-arking (<xref target="observed-re-marking">Re-mark-DSCP</xref>) to a single DSCP, which can limit
+  	(<xref target="observed-re-marking">Bleach-DSCP</xref>) or re-marking (<xref target="observed-re-marking">Re-mark-DSCP</xref>) to a single DSCP, which can limit
    	the ability to provide the expected treatment end-to-end.  This is
    	particularly important for cases where the codepoint is intended to
   	result in lower than best effort treatment, as was the case when


### PR DESCRIPTION
### S5.1.2
* "(wireless-to-wired interconnections," -> "(wireless-to-wired interconnections)," ### S6.4
* The term "re-mark" is use here, whereas it seems like "remark" (no hyphen) is used throughout the rest of the document. (Personally, I prefer "re-mark", to distinguish it from the regular English word having to do with observing or commenting, but that's just me.) ### S6.5
* In the 4th bullet, I assume "ID" here is actually "I-D" as in "Internet  draft"?